### PR TITLE
Revert "Fix JwtAuthentication import path"

### DIFF
--- a/organizations/v0/views.py
+++ b/organizations/v0/views.py
@@ -2,7 +2,7 @@
 """
 Views for organizations end points.
 """
-from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
+from edx_rest_framework_extensions.authentication import JwtAuthentication
 from rest_framework import viewsets
 from rest_framework.authentication import SessionAuthentication
 from rest_framework.permissions import IsAuthenticated


### PR DESCRIPTION
This reverts commit 3c7a2483b5b6e4033ddd3c0320d7e26dff1ccba3 of #1 

Because of:

```
 File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/organizations/v0/views.py", line 5, in <module>
    from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
ImportError: No module named auth.jwt.authentication
```

More [details in Slack](https://appsembler.slack.com/archives/CCT7XSP9D/p1542182370011000).

It's likely that I've got the issue because of different `edx-drf-extensions` between this package's requirement files and the ones in the edX platform.