### PR TITLE
Admin performance fixes for UserOrganizationMapping

### DIFF
--- a/organizations/__init__.py
+++ b/organizations/__init__.py
@@ -1,4 +1,4 @@
 """
 edx-organizations app initialization module
 """
-__version__ = '0.4.12-appsembler4'  # pragma: no cover
+__version__ = '0.4.12-appsembler5'  # pragma: no cover

--- a/organizations/admin.py
+++ b/organizations/admin.py
@@ -4,10 +4,6 @@ from organizations.models import (Organization, OrganizationCourse, UserOrganiza
 from django.utils.translation import ugettext_lazy as _
 
 
-class UserOrganizationMappingInline(admin.TabularInline):
-    model = UserOrganizationMapping
-    extra = 1
-
 @admin.register(Organization)
 class OrganizationAdmin(admin.ModelAdmin):
     """ Admin for the Organization model. """
@@ -17,7 +13,6 @@ class OrganizationAdmin(admin.ModelAdmin):
     ordering = ('name', 'short_name',)
     readonly_fields = ('created',)
     search_fields = ('name', 'short_name',)
-    inlines = [UserOrganizationMappingInline, ]
     actions = ['activate_selected', 'deactivate_selected']
 
     def get_actions(self, request):
@@ -71,3 +66,35 @@ class OrganizationCourseAdmin(admin.ModelAdmin):
             kwargs['queryset'] = Organization.objects.filter(active=True).order_by('name')
 
         return super(OrganizationCourseAdmin, self).formfield_for_foreignkey(db_field, request, **kwargs)
+
+
+@admin.register(UserOrganizationMapping)
+class UserOrganizationMappingAdmin(admin.ModelAdmin):
+    list_display = [
+        'email',
+        'username',
+        'organization_name',
+        'is_active',
+        'is_amc_admin',
+    ]
+
+    search_fields = [
+        'user__email',
+        'user__username',
+        'organization__name',
+        'organization__short_name',
+    ]
+
+    list_filter = [
+        'is_active',
+        'is_amc_admin',
+    ]
+
+    def email(self, mapping):
+        return mapping.user.email
+
+    def username(self, mapping):
+        return mapping.user.username
+
+    def organization_name(self, mapping):
+        return mapping.organization.short_name

--- a/organizations/models.py
+++ b/organizations/models.py
@@ -9,6 +9,7 @@ from django.contrib.sites.models import Site
 from django.core.exceptions import ValidationError
 from django.db import models
 from django.conf import settings
+from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
 from model_utils.models import TimeStampedModel
 
@@ -81,11 +82,18 @@ class OrganizationCourse(TimeStampedModel):
         verbose_name_plural = _('Link Courses')
 
 
+@python_2_unicode_compatible
 class UserOrganizationMapping(models.Model):
     user = models.ForeignKey(settings.AUTH_USER_MODEL)
     organization = models.ForeignKey(Organization)
     is_active = models.BooleanField(default=True)
     is_amc_admin = models.BooleanField(default=False)
+
+    def __str__(self):
+        return 'UserOrganizationMapping<{email}, {organization}>'.format(
+            email=self.user.email,
+            organization=self.organization.short_name,
+        )
 
 
 class UserSiteMapping(models.Model):


### PR DESCRIPTION
`UserOrganizationMappingInline` breaks when there's too many users esp. when nginx sets a limit on request time. Therefore we see the following image:

<kbd>![image](https://user-images.githubusercontent.com/645156/83853771-6d21a380-a71e-11ea-8e67-f3c30f62974e.png)</kbd>

Jira ticket: https://appsembler.atlassian.net/browse/RED-451