### PR TITLE
RED-1496: Merge tag v2.1.0 from upstream (Juniper 1 of 3)

### DIFF
--- a/organizations/__init__.py
+++ b/organizations/__init__.py
@@ -1,4 +1,4 @@
 """
 edx-organizations app initialization module
 """
-__version__ = '2.0.3'  # pragma: no cover
+__version__ = '2.1.0'  # pragma: no cover

--- a/organizations/data.py
+++ b/organizations/data.py
@@ -50,26 +50,26 @@ def _inactivate_record(record):
     record.save()
 
 
-def _activate_organization(organization):
+def _activate_organization(organization_id):
     """
     Activates an inactivated (soft-deleted) organization as well as any inactive relationships
     """
     [_activate_organization_course_relationship(record) for record
-     in internal.OrganizationCourse.objects.filter(organization_id=organization.id, active=False)]
+     in internal.OrganizationCourse.objects.filter(organization_id=organization_id, active=False)]
 
     [_activate_record(record) for record
-     in internal.Organization.objects.filter(id=organization.id, active=False)]
+     in internal.Organization.objects.filter(id=organization_id, active=False)]
 
 
-def _inactivate_organization(organization):
+def _inactivate_organization(organization_id):
     """
     Inactivates an activated organization as well as any active relationships
     """
     [_inactivate_organization_course_relationship(record) for record
-     in internal.OrganizationCourse.objects.filter(organization_id=organization.id, active=True)]
+     in internal.OrganizationCourse.objects.filter(organization_id=organization_id, active=True)]
 
     [_inactivate_record(record) for record
-     in internal.Organization.objects.filter(id=organization.id, active=True)]
+     in internal.Organization.objects.filter(id=organization_id, active=True)]
 
 
 def _activate_organization_course_relationship(relationship):  # pylint: disable=invalid-name
@@ -116,7 +116,7 @@ def create_organization(organization):
         )
         # If the organization exists, but was inactivated, we can simply turn it back on
         if not organization.active:
-            _activate_organization(organization_obj)
+            _activate_organization(organization.id)
     except internal.Organization.DoesNotExist:
         organization = internal.Organization.objects.create(
             name=organization_obj.name,
@@ -152,7 +152,7 @@ def delete_organization(organization):
     No return currently defined for this operation
     """
     organization_obj = serializers.deserialize_organization(organization)
-    _inactivate_organization(organization_obj)
+    _inactivate_organization(organization_obj.id)
 
 
 def fetch_organization(organization_id):

--- a/organizations/management/commands/add_organization.py
+++ b/organizations/management/commands/add_organization.py
@@ -1,0 +1,42 @@
+"""
+Add an organization through manage.py.
+"""
+import logging
+
+from django.core.management import BaseCommand, CommandError
+
+from organizations import api
+
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    """Management command used to add an organization.
+
+    Example: ./manage.py add_organization hogwarts "Hogwarts School of Witchcraft and Wizardry"
+    """
+
+    def add_arguments(self, parser):
+        parser.add_argument('short_name')
+        parser.add_argument('name')
+
+    def handle(self, *args, **options):
+        org_options = {
+            key: options[key] for key in {'short_name', 'name'}
+        }
+
+        if len(org_options['short_name']) > len(org_options['name']):
+            fmt = (
+                "The provided short_name ({short_name}) "
+                "is longer than the provided name ({name}). "
+                "You probably want to switch the order of the arguments."
+            )
+            raise CommandError(fmt.format(**org_options))
+
+        created_org = api.add_organization(org_options)
+        log_fmt = (
+            "Created or activated organization: id={id}, "
+            "short_name={short_name}, name='{name}'"
+        )
+        logger.info(log_fmt.format(**created_org))

--- a/organizations/management/commands/tests/test_add_organization.py
+++ b/organizations/management/commands/tests/test_add_organization.py
@@ -1,0 +1,44 @@
+"""
+Tests for organization-adding management command.
+"""
+from django.core.management import call_command, CommandError
+from django.test import TestCase
+
+from organizations.models import Organization
+
+
+class TestAddOrganizationCommand(TestCase):
+    """ Tests for add_organization.Command. """
+
+    ORG_SHORT_NAME = "msw"
+    ORG_NAME = "Ministry of Silly Walks"
+
+    def assert_one_active_organization(self, short_name, name):
+        """
+        Assert that there is exactly one organization with the given short_name,
+        and if so, that it has the specified name and is active.
+        """
+        # Fails with MultipleObjectsReturned if >1 orgs matching `short_name`
+        org = Organization.objects.get(short_name=short_name)
+        self.assertEqual(org.name, name)
+        self.assertTrue(org.active)
+
+    def test_add_org(self):
+        call_command('add_organization', self.ORG_SHORT_NAME, self.ORG_NAME)
+        self.assert_one_active_organization(self.ORG_SHORT_NAME, self.ORG_NAME)
+
+    def test_add_same_org_twice(self):
+        call_command('add_organization', self.ORG_SHORT_NAME, self.ORG_NAME)
+        call_command('add_organization', self.ORG_SHORT_NAME, self.ORG_NAME)
+        self.assert_one_active_organization(self.ORG_SHORT_NAME, self.ORG_NAME)
+
+    def test_add_existing_org(self):
+        Organization.objects.create(
+            short_name=self.ORG_SHORT_NAME, name=self.ORG_NAME, active=False
+        )
+        call_command('add_organization', self.ORG_SHORT_NAME, self.ORG_NAME)
+        self.assert_one_active_organization(self.ORG_SHORT_NAME, self.ORG_NAME)
+
+    def test_bad_argument_order(self):
+        with self.assertRaises(CommandError):
+            call_command('add_organization', self.ORG_NAME, self.ORG_SHORT_NAME)

--- a/organizations/tests/test_api.py
+++ b/organizations/tests/test_api.py
@@ -43,7 +43,7 @@ class OrganizationsApiTestCase(utils.OrganizationsTestCaseBase):
             organization = api.add_organization(organization_data)
 
     def test_add_organization_inactive_to_active(self):
-        """ Unit Test: test_add_organization_inactive_organization_present"""
+        """ Unit Test: test_add_organization_inactive_to_active"""
         organization_data = {
             'name': 'local_organizationßßß',
             'description': 'Local Organization Descriptionßßß'
@@ -52,8 +52,12 @@ class OrganizationsApiTestCase(utils.OrganizationsTestCaseBase):
         self.assertGreater(organization['id'], 0)
         api.remove_organization(organization['id'])
 
-        with self.assertNumQueries(3):
+        with self.assertNumQueries(5):
             organization = api.add_organization(organization_data)
+
+        # Assert that the organization is active by making sure we can load it.
+        loaded_organization = api.get_organization(organization['id'])
+        self.assertEqual(loaded_organization['name'], organization_data['name'])
 
     def test_add_organization_inactive_organization_with_relationships(self):
         """ Unit Test: test_add_organization_inactive_organization_with_relationships"""

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -14,13 +14,13 @@ djangorestframework-jwt==1.11.0  # via edx-drf-extensions
 djangorestframework-oauth==1.1.0
 djangorestframework==3.9.4
 edx-django-oauth2-provider==1.3.5
-edx-django-utils==1.0.3   # via edx-drf-extensions
+edx-django-utils==1.0.5   # via edx-drf-extensions
 edx-drf-extensions==2.3.1
-edx-opaque-keys==1.0.0
+edx-opaque-keys==1.0.1
 future==0.17.1            # via pyjwkest
 idna==2.8                 # via requests
 newrelic==4.20.0.120      # via edx-django-utils
-pbr==5.2.1                # via stevedore
+pbr==5.3.0                # via stevedore
 pillow==6.0.0
 psutil==1.2.1             # via edx-django-utils, edx-drf-extensions
 pycryptodomex==3.8.2      # via pyjwkest

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -9,13 +9,13 @@ chardet==3.0.4            # via requests
 django-model-utils==3.1.2
 django-simple-history==2.7.2
 django-waffle==0.16.0     # via edx-django-utils, edx-drf-extensions
-django==1.11.20
+django==1.11.21
 djangorestframework-jwt==1.11.0  # via edx-drf-extensions
 djangorestframework-oauth==1.1.0
 djangorestframework==3.9.4
 edx-django-oauth2-provider==1.3.5
 edx-django-utils==1.0.3   # via edx-drf-extensions
-edx-drf-extensions==2.3.0
+edx-drf-extensions==2.3.1
 edx-opaque-keys==1.0.0
 future==0.17.1            # via pyjwkest
 idna==2.8                 # via requests

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,7 +6,7 @@
 #
 certifi==2019.6.16        # via requests
 chardet==3.0.4            # via requests
-django-model-utils==3.1.2
+django-model-utils==3.2.0
 django-simple-history==2.7.2
 django-waffle==0.16.0     # via edx-django-utils, edx-drf-extensions
 django==1.11.21
@@ -19,7 +19,7 @@ edx-drf-extensions==2.3.1
 edx-opaque-keys==1.0.1
 future==0.17.1            # via pyjwkest
 idna==2.8                 # via requests
-newrelic==4.20.0.120      # via edx-django-utils
+newrelic==4.20.1.121      # via edx-django-utils
 pbr==5.3.1                # via stevedore
 pillow==6.0.0
 psutil==1.2.1             # via edx-django-utils, edx-drf-extensions

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-certifi==2019.3.9         # via requests
+certifi==2019.6.16        # via requests
 chardet==3.0.4            # via requests
 django-model-utils==3.1.2
 django-simple-history==2.7.2
@@ -20,7 +20,7 @@ edx-opaque-keys==1.0.1
 future==0.17.1            # via pyjwkest
 idna==2.8                 # via requests
 newrelic==4.20.0.120      # via edx-django-utils
-pbr==5.3.0                # via stevedore
+pbr==5.3.1                # via stevedore
 pillow==6.0.0
 psutil==1.2.1             # via edx-django-utils, edx-drf-extensions
 pycryptodomex==3.8.2      # via pyjwkest

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -6,7 +6,7 @@
 #
 astroid==1.5.3            # via edx-lint, pylint, pylint-celery
 backports.functools-lru-cache==1.5  # via astroid, isort, pylint
-certifi==2019.3.9
+certifi==2019.6.16
 chardet==3.0.4
 click-log==0.1.8          # via edx-lint
 click==7.0                # via click-log, edx-lint
@@ -41,7 +41,7 @@ mccabe==0.6.1             # via pylint
 newrelic==4.20.0.120
 nose==1.3.7
 pathlib2==2.3.3           # via importlib-metadata
-pbr==5.3.0
+pbr==5.3.1
 pep8==1.7.1
 pillow==6.0.0
 pluggy==0.12.0            # via tox
@@ -69,8 +69,8 @@ text-unidecode==1.2       # via faker
 toml==0.10.0              # via tox
 tox==3.12.1
 urllib3==1.25.3
-virtualenv==16.6.0        # via tox
-wrapt==1.11.1             # via astroid
+virtualenv==16.6.1        # via tox
+wrapt==1.11.2             # via astroid
 zipp==0.5.1               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -14,7 +14,7 @@ configparser==3.7.4       # via importlib-metadata, pylint
 contextlib2==0.5.5        # via importlib-metadata
 coverage==4.5.3
 ddt==1.1.0
-django-model-utils==3.1.2
+django-model-utils==3.2.0
 django-nose==1.4.6
 django-simple-history==2.7.2
 django-waffle==0.16.0
@@ -33,14 +33,15 @@ future==0.17.1
 futures==3.2.0 ; python_version == "2.7"  # via isort
 httpretty==0.9.6
 idna==2.8
-importlib-metadata==0.18  # via pluggy
+importlib-metadata==0.18  # via pluggy, tox
 ipaddress==1.0.22         # via faker
-isort==4.3.20             # via pylint
+isort==4.3.21             # via pylint
 lazy-object-proxy==1.4.1  # via astroid
 mccabe==0.6.1             # via pylint
-newrelic==4.20.0.120
+newrelic==4.20.1.121
 nose==1.3.7
-pathlib2==2.3.3           # via importlib-metadata
+packaging==19.0           # via tox
+pathlib2==2.3.4           # via importlib-metadata
 pbr==5.3.1
 pep8==1.7.1
 pillow==6.0.0
@@ -55,6 +56,7 @@ pylint-django==0.7.2      # via edx-lint
 pylint-plugin-utils==0.5  # via pylint-celery, pylint-django
 pylint==1.7.6             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 pymongo==3.8.0
+pyparsing==2.4.0          # via packaging
 python-dateutil==2.8.0
 pytz==2019.1
 requests==2.22.0
@@ -67,11 +69,8 @@ six==1.12.0
 stevedore==1.30.1
 text-unidecode==1.2       # via faker
 toml==0.10.0              # via tox
-tox==3.12.1
+tox==3.13.1
 urllib3==1.25.3
 virtualenv==16.6.1        # via tox
 wrapt==1.11.2             # via astroid
 zipp==0.5.1               # via importlib-metadata
-
-# The following packages are considered to be unsafe in a requirements file:
-# setuptools==41.0.1        # via tox

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -22,7 +22,7 @@ djangorestframework-jwt==1.11.0
 djangorestframework-oauth==1.1.0
 edx-django-oauth2-provider==1.3.5
 edx-django-utils==1.0.3
-edx-drf-extensions==2.3.0
+edx-drf-extensions==2.3.1
 edx-lint==0.6.0
 edx-opaque-keys==1.0.0
 enum34==1.1.6             # via astroid
@@ -72,3 +72,6 @@ urllib3==1.25.3
 virtualenv==16.6.0        # via tox
 wrapt==1.11.1             # via astroid
 zipp==0.5.1               # via importlib-metadata
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools==41.0.1        # via tox

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -21,10 +21,10 @@ django-waffle==0.16.0
 djangorestframework-jwt==1.11.0
 djangorestframework-oauth==1.1.0
 edx-django-oauth2-provider==1.3.5
-edx-django-utils==1.0.3
+edx-django-utils==1.0.5
 edx-drf-extensions==2.3.1
 edx-lint==0.6.0
-edx-opaque-keys==1.0.0
+edx-opaque-keys==1.0.1
 enum34==1.1.6             # via astroid
 factory-boy==2.12.0
 faker==1.0.7              # via factory-boy
@@ -33,7 +33,7 @@ future==0.17.1
 futures==3.2.0 ; python_version == "2.7"  # via isort
 httpretty==0.9.6
 idna==2.8
-importlib-metadata==0.17  # via pluggy
+importlib-metadata==0.18  # via pluggy
 ipaddress==1.0.22         # via faker
 isort==4.3.20             # via pylint
 lazy-object-proxy==1.4.1  # via astroid
@@ -41,7 +41,7 @@ mccabe==0.6.1             # via pylint
 newrelic==4.20.0.120
 nose==1.3.7
 pathlib2==2.3.3           # via importlib-metadata
-pbr==5.2.1
+pbr==5.3.0
 pep8==1.7.1
 pillow==6.0.0
 pluggy==0.12.0            # via tox


### PR DESCRIPTION
Just like #6. This PR brings our `edx-organization` fork up to Juniper but only up to `v2.1.0` which is the version in [release-2019-09-20-11.16](https://github.com/edx/edx-platform/blame/release-2019-09-20-11.16/requirements/edx/base.txt#L112).

Issues: RED-1491 (and RED-1496)


Tests passes locally:


```
organizations/v0/tests/test_views.py                                  47      0      0      0   100%
organizations/v0/urls.py                                               6      0      0      0   100%
organizations/v0/views.py                                             14      0      0      0   100%
organizations/validators.py                                           22      1     10      1    94%
----------------------------------------------------------------------------------------------------
TOTAL                                                                736     96     80      3    85%
___________________ summary _____________________________
  py27-django111-drf36: commands succeeded
  congratulations :)
```